### PR TITLE
fix: disable dnd auto scroll

### DIFF
--- a/src/components/providers/GameProvider.tsx
+++ b/src/components/providers/GameProvider.tsx
@@ -69,7 +69,7 @@ const GameProvider: React.FC<Props> = ({ game, children }) => {
 
   return (
     <GameContext.Provider value={{ ...game, getNewIndex }}>
-      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+      <DndContext sensors={sensors} onDragEnd={onDragEnd} autoScroll={false}>
         <SortableContext items={tileIDs} strategy={rectSwappingStrategy}>
           {children}
         </SortableContext>


### PR DESCRIPTION
This fixes an issue experienced on mobile devices when dragging a tile to the edge of the screen