### PR TITLE
fix: update layout styles for mobile displays

### DIFF
--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -38,4 +38,6 @@ const Container = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   max-width: 350px;
+  height: fit-content;
+  margin: auto;
 `;

--- a/src/components/rack/Rack.tsx
+++ b/src/components/rack/Rack.tsx
@@ -38,6 +38,7 @@ const Container = styled.div`
   justify-content: center;
   margin-top: 2.5px;
   margin-bottom: 2.5px;
+  height: fit-content;
 `;
 
 export default Rack;


### PR DESCRIPTION
This fixes an issue where the board and rack were oldy spaced on mobile displays