### PR TITLE
fix: prevent blank rack tiles from being dragged

### DIFF
--- a/src/components/rack/Rack.tsx
+++ b/src/components/rack/Rack.tsx
@@ -19,6 +19,7 @@ const Rack: React.FC = () => {
                 state={tile.getState()}
                 id={tile.getID()}
                 letter={tile.getLetter()}
+                draggable={tile.isDraggable()}
                 size="small"
               />
             ))


### PR DESCRIPTION
Closes #111 