### PR TITLE
fix: update share logic to remove text

### DIFF
--- a/cypress/e2e/share.cy.ts
+++ b/cypress/e2e/share.cy.ts
@@ -36,8 +36,7 @@ describe("Share", () => {
 
       const firstArgument = args[0];
 
-      expect(firstArgument).to.have.property("title", "Whittle");
-      expect(firstArgument).to.have.property("text", "Daily Whittle #2");
+      expect(firstArgument).to.have.property("title", "Daily Whittle #2");
       expect(firstArgument.files).to.have.lengthOf(1);
     });
   });

--- a/src/components/modals/statistics/ShareButton.tsx
+++ b/src/components/modals/statistics/ShareButton.tsx
@@ -46,8 +46,7 @@ const ShareButton: React.FC = () => {
         });
 
         navigator.share({
-          title: "Whittle",
-          text: `Daily Whittle #${number}`,
+          title: `Daily Whittle #${number}`,
           files: [image],
         });
       }


### PR DESCRIPTION
This removes the text argument as this is likely what's preventing images being shared on IOS devices. The text itself is also quite redundant given the image already displays the game number.

Closes #119 