### PR TITLE
feat: update share logic

### DIFF
--- a/cypress/e2e/share.cy.ts
+++ b/cypress/e2e/share.cy.ts
@@ -36,7 +36,6 @@ describe("Share", () => {
 
       const firstArgument = args[0];
 
-      expect(firstArgument).to.have.property("title", "Daily Whittle #2");
       expect(firstArgument.files).to.have.lengthOf(1);
     });
   });

--- a/src/components/modals/statistics/ShareButton.tsx
+++ b/src/components/modals/statistics/ShareButton.tsx
@@ -45,10 +45,7 @@ const ShareButton: React.FC = () => {
           type: blob.type,
         });
 
-        navigator.share({
-          title: `Daily Whittle #${number}`,
-          files: [image],
-        });
+        navigator.share({ files: [image] });
       }
     }
   };


### PR DESCRIPTION
After testing the latest change to the share button on IOS, looks like it's still not sharing the image on WhatsApp. Hopefully this should do it.